### PR TITLE
feat(app-header): run tests against feature branch in ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/*.js
 build/reports
 fonts
 demo/elements.css
+app-header.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 - 4.2
 script:
 - npm run ci
+- chmod 777 ./test/shell_scripts/run_tests.sh
+- "./test/shell_scripts/run_tests.sh"
 after_success:
 - cat ./build/reports/coverage/coverage.lcov | node_modules/coveralls/bin/coveralls.js
 after_failure:
@@ -12,10 +14,13 @@ after_failure:
   || true
 deploy:
   provider: npm
-  email: pearson-design-accelerator@pearson.com
+  email: pearson-design-accelerato@pearson.com
   api_key:
     secure: I7MhEd++LqQyxQcivH7thVwazRHmV1By4TzjdKicHHur4qHaQzjiq5a5pM7LtPzrDbgxZapBwA/9okz13iSGeqG+/Nks8Nc2ac1wGOpnewnOSNnCw4e8tJT7Ug88s5cdcIfKeA0GhzUrRie5xEADBk1+9T+UXUujGiUNYcVftmqwV2xEHeE2FqjLGat0OLLx33llpM7ppt3pC00W7dRz/1IEY1Ov/U4lSqEqlppGfbLhi3X7SrgK66eqAiBS21lHUc2EF+/9Z5cebYjVMB6Wlbb6DcbYsm2rUEXiNmKu23P89yOBgLx9VEImDnyfOAfwGXX0H8fHgDXXC0dQboC9pCcBMbe6v4PH9zg0qs2pfUbsBTEX8m376dI1jm8RZhwVAQ0o1wsqLe0d11+p9hEROp0vs4Vgi7Uern7Fzyvpsi/b/ZpxIxbldqbhyb9GVgcrepfBvG3OFCVxNTcjYjyUjn1BATHZA9MdFQgsZTf//AjsbuQp6KGEPzCUTRLlzc5TvJ6LwsPw5Kvbj5hTLUblcgbPNTQH31vcHxkqWaQ8cnwSFinjiKJtdYn5SCHHpMLxdGSg2Pr16mNP+uByf6/A7tpb304TOJGzv3WQdZrwaOTG0KFRIGb4Lurjn+sZXzIsKkboUsJDijdnuxOLCl5a7aPT0JfP+I2IR0GHcAdpG0M=
   skip_cleanup: true
   on:
     branch: master
     tags: true
+env:
+  global:
+    secure: kPNh4Tg8CgJsxrA4ictCXj1IU1d6Q+0f7XtXBIGI9cFhYruC13nP1kT2IrTrW1OrfsHuvBg3Lb6uBAEA/oPIt1zRWhCfUXGkOwbM//ogLviMFCW+jJOsbGJ2KljTOfPQ/BWFPJH1MaxHovvgsfTkxxwIXBlsqGOiFtNBVKL+x2KitKyLMSMqd1v1mqzEZUHY97gwc7TsGUxBEt4fN84XTx0zqfJz88/fhLp5B17LHHH92PlwtD/Pg+EfLMgmTuBtz0MVMrmyDgBnqGhi2dSuNSPW1FBeWSot/MU2+j426+NfgNt+uSl6GLLlPD0MQIEjgwrSnXnsODhQ8d/dbJ5l5df6gnsbheQD+h/feqTyB3D4Bg82HdIKJpa8SXvPze1FjiSHH6ejSdmoLedSAxZYGNP40eOpW7OCme/COBCYuGuHVl02XuWBZLlNQAYdZ0Vg3PnWbJYzu/I3UyoGKxWBF5Chb7k18z57nxwN+aTy/5nCu250bqMH0xldxyrU/pFfR2pALPlhlCbvoaJTDD2HRyM8R56lXHxSgpMFZl6uxMbzltx/j1CiYcTkxEEh/v78BRSOqjVAazTcoSMrLTN27akzjPRcbjZPb9UoyKQ+LhXFngw4Wz34geGntVtKxD3OkCho9TQ6Vtmn974d9j6TyaQKBeo6UqDrPw31+92cm64=

--- a/app-header.iml
+++ b/app-header.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/test/shell_scripts/run_tests.sh
+++ b/test/shell_scripts/run_tests.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+echo "Trigger the Selenium tests for master branch: ux-test-platform repo...."
+
+#Step 1: API to trigger the ux-test-platform build with the below config
+body="{
+\"request\": {
+\"message\": \"feat(app-header): Run App Header Tests\",
+\"branch\":\"master\",
+\"config\": {
+\"script\": [
+\"export component=app-header\",
+\"export feature_branch=$TRAVIS_BRANCH\",
+\"chmod 777 ./src/main/shell_scripts/components.sh\",
+\"./src/main/shell_scripts/components.sh\",
+\"mvn -Dtest_suite_xml=app_header.xml test\"
+]
+}
+}}"
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token $AUTH_TOKEN" \
+  -d "$body" \
+  https://api.travis-ci.org/repo/Pearson-Higher-Ed%2Fux-test-platform/requests
+
+echo ""
+echo "Waiting for approximately 5s for the Selenium tests to trigger..."
+echo ""
+
+REPO_URI="https://api.travis-ci.org/repos/Pearson-Higher-Ed/ux-test-platform/builds"
+i=1
+max=20
+while [ $i -lt $max ]
+do  
+  curl -i $REPO_URI > test.json #Push the json response to a temp file 'test.json'
+
+  LATEST_STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of the last build
+  LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #Fetch the id of the last build
+  BRANCH=$(grep -o '"branch":.[a-z\"]*' test.json | head -1 ) #Fetch the branch name of the last build
+
+  get_state_value=${BRANCH#*:}
+  BRANCH="${get_state_value//\"}"
+
+  if [ $BRANCH == "master" ] #If condition to check if the last triggered build is master
+    sleep 5
+    curl -i $REPO_URI > test.json
+  then LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #
+  echo "LATEST_ID of master branch.............................. $LATEST_ID"
+  export LATEST_ID
+    break 
+  else  
+    true $(( i++ ))
+    sleep 1
+  fi
+done
+
+#Step 2 : Fetch the build status of the 'master' branch
+get_buildId_value=${LATEST_ID#*:}
+BUILD_ID="${get_buildId_value//\"}"
+
+REPO_URI_WITH_BUILDID="$REPO_URI/$BUILD_ID"
+echo $REPO_URI_WITH_BUILDID
+
+i=1
+max=900 #Max time for the tests to run.
+while [ $i -lt $max ]
+do
+
+curl -i $REPO_URI_WITH_BUILDID > test.json 
+
+STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of master build
+#RESULT=$(grep -o '"result":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #For debug
+STATUS=$(grep -o '"status":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #Fetch the status of master build
+
+echo "--------------------------------------------"
+echo "Polling for the tests run build status..."
+echo "ux-test-platform build run in progress: https://travis-ci.org/Pearson-Higher-Ed/ux-test-platform/builds/$BUILD_ID"
+
+get_state_value=${STATE#*:}
+STATE="${get_state_value//\"}"
+
+get_status_value=${STATUS#*:}
+STATUS="${get_status_value//\"}"
+
+if [ $STATUS == "0" ] #Success condition
+then
+  echo "counter-> $i"
+  echo "TESTS RUN... PASSED :-) "
+  break #As soon as the tests run pass, we break and return back to the elements build run
+elif [ $STATUS == "1" ] #Failure condition
+then
+ echo "TESTS RUN... FAILED :-("
+ exit 1 #As soon as the tests run fail, we stop building elements
+elif [[ $STATE == "finished" && $STATUS == "n" ]] #Unexpected failure due to Travis environment issues
+then
+ echo "TESTS RUN... NULL :-("
+ exit 1 #For some reason, if the ux-test-platform build breaks or halts
+elif [ $i == "900" ] #Maxed out condition
+  then
+  echo "ux-test-platform run time has maxed out..."
+  exit 1 #Selenium tests run for more than the max time.
+fi
+
+true $(( i++ ))
+sleep 1 #This 1s is required to poll the build status for every second
+echo "counter-> $i"
+done


### PR DESCRIPTION
Add more info to the Travis API that will trigger ux-test-platform's app-header test suite only.
And export feature branch name to ux-test-platform, that way the tests point to feature_branch of app-header only.