### PR TITLE
fix(css): iphone5 screen size was wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ to manage them.
 
 ### Demo
 
-The following npm script will build the component, fire up a webpack dev server at localhost:8080/demo, and hot reload 
+The following npm script will build the component, fire up a webpack dev server at localhost:8081/demo, and hot reload
 any saved changes to the source without having to refresh the browser.
 
 	npm install

--- a/src/scss/header/scss/_variables.scss
+++ b/src/scss/header/scss/_variables.scss
@@ -45,6 +45,7 @@ $o-header-z-index: 1000 !default;
 /// Responsive breakpoints
 
 // Phone
+$o-header-phone-xs-max: 320px !default;
 $o-header-phone-sm-max: 479px !default;
 $o-header-phone-min: $o-header-phone-sm-max + 1 !default;
 $o-header-phone-max: 767px !default;

--- a/src/scss/header/scss/brand.scss
+++ b/src/scss/header/scss/brand.scss
@@ -11,4 +11,8 @@
 	@media (min-width: $o-header-desktop-min) {
 		height: $o-header-height;
 	}
+
+    @media (max-width: $o-header-phone-xs-max) {
+        padding: 0 7px;
+    }
 }


### PR DESCRIPTION
small screens (iphone5) caused the header to wrap now that notification bell has been added. Adjusting the padding gives enough space for everything to fit. Not sure if you prefer a more scalable solution or not, as adding anything more to the list of items will cause more wrapping :)
