### PR TITLE
Adjusted text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Creates a new instance of `AppHeader`.
 | links                    | `object`               | Links in the user dropdown. Refer to the [Links](#links) section for the default list  |
 | mode                     | `string`               | The mode. Refer to the [Modes](#modes) section for a list of supported modes and options. |
 
-
+It is in this `options` object that you change the URLs and names of the links, including the home link. The name of the home link should be "Pearson [name of your application] home". y default it is just "home".
 
 ```js
 var AppHeader = require('@pearson-components/app-header');

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Creates a new instance of `AppHeader`.
 | links                    | `object`               | Links in the user dropdown. Refer to the [Links](#links) section for the default list  |
 | mode                     | `string`               | The mode. Refer to the [Modes](#modes) section for a list of supported modes and options. |
 
-It is in this `options` object that you change the URLs and names of the links, including the home link. The name of the home link should be "Pearson [name of your application] home". y default it is just "home".
+It is in this `options` object that you change the URLs and names of the links, including the home link. The name of the home link should be "Pearson [name of your application] home". The default is just "home".
 
 ```js
 var AppHeader = require('@pearson-components/app-header');


### PR DESCRIPTION
I can't see a way to do this. The translate function doesn't, so far as I know, know how to split text. Either I remove the translation ability entirely, which means in all languages the default is "home" and consuming teams can't get "home" translated, or I leave it and hope they change the whole string. I actually don't see how the options are inserting the text because all the text is hard-coded into the header.template anyway so if it's changing those too (if someone has to change a URL and a link name) then I don't see how those would get translated without them making changes to the header.template (to wrap translate around their own string).

So all I did was change the README.