### PR TITLE
two Header Logo's break in Internet Explorer #57

### DIFF
--- a/src/scss/header/scss/logo-tagline.scss
+++ b/src/scss/header/scss/logo-tagline.scss
@@ -28,14 +28,6 @@
 
 }
 
-.o-header__logo--pearson img {
-	height: 37px;
-
-	@media (max-width: $o-header-phone-max) {
-		height: 30px;
-	}
-}
-
 .logo-seperator{
 	box-sizing: border-box;
 	border-right: 1px solid #ccc;


### PR DESCRIPTION
Seems the issue will be fixed when removing the fixed height, and the separate projects can add their own heights for the Logo's